### PR TITLE
fix: use valid pull_request event in workflow trigger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Main workflow
-on: [push, pull-request]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
## Root cause

The latest CI run on `master` (run #33, `Update GitHub Actions versions`) failed immediately with **zero jobs executed**. This is the signature of an invalid workflow file, not a code/test/lint failure.

`.github/workflows/test.yml` declared:

```yaml
on: [push, pull-request]
```

`pull-request` is **not** a valid GitHub Actions event name — the correct event is `pull_request` (underscore, not hyphen). GitHub rejects the entire workflow file as invalid, so every triggered run fails before any job starts. The invalid trigger was introduced in commit `7677bf8` ("add pull-request trigger").

This is a genuine configuration bug. The `actions/checkout@v6` / `actions/setup-python@v6` bumps are valid, so no action pinning was needed, and there is no EOL-Emacs matrix involved.

## Fix

Rename the trigger to the valid `pull_request` event:

```yaml
on: [push, pull_request]
```

With a valid workflow file, the run parses and the `build` job executes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZvt7pmCUJTKKALKmCY3cT)_