### PR TITLE
chore: update clojure dependencies to latest versions

### DIFF
--- a/clojure/dali/project.clj
+++ b/clojure/dali/project.clj
@@ -3,13 +3,13 @@
   :url "http://example.com/FIXME"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.12.5"]
                  ;; http server
-                 [compojure "1.6.1"]
-                 [ring "1.7.1"]
+                 [compojure "1.7.2"]
+                 [ring "1.15.4"]
 
                  ;; svg utility
-                 [dali "0.7.4"]]
+                 [dali "1.0.2"]]
   ;; :main ^:skip-aot conao3.dali.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/clojure/lein-app/project.clj
+++ b/clojure/lein-app/project.clj
@@ -3,7 +3,7 @@
   :url "http://example.com/FIXME"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
-  :dependencies [[org.clojure/clojure "1.9.0"]]
+  :dependencies [[org.clojure/clojure "1.12.5"]]
   :main ^:skip-aot conao3.lein-app.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})


### PR DESCRIPTION
## Summary

Modernizes the Leiningen-managed Clojure dependencies (the only declared
third-party dependencies in this multi-language playground) to their latest
releases from Clojars / Maven Central.

### `clojure/dali/project.clj`

| Dependency | Old | New |
| --- | --- | --- |
| org.clojure/clojure | 1.9.0 | 1.12.5 |
| compojure | 1.6.1 | 1.7.2 |
| ring | 1.7.1 | 1.15.4 |
| dali | 0.7.4 | 1.0.2 |

### `clojure/lein-app/project.clj`

| Dependency | Old | New |
| --- | --- | --- |
| org.clojure/clojure | 1.9.0 | 1.12.5 |

### Notes

- No lockfiles exist (Leiningen uses `project.clj` directly; there is no
  `deps.edn`). The Go code (`go/github-api`) has no `go.mod` and uses only
  the standard library, so there are no Go dependencies to bump.
- All bumps go to the latest stable releases, including the major bumps
  `dali 0.7.4 → 1.0.2` and `ring 1.7.1 → 1.15.4`. The APIs used in
  `clojure/dali/src/conao3/dali/core.clj` (`dali.io/render-png`,
  `ring.adapter.jetty`, `ring.util.response`, `compojure.core`/`route`)
  are unchanged across these versions.
- No major upgrades were deferred.

## Test plan

- [x] `make all` / `make test` (the build & CI target) pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01HT7zgvGzMV2Z65UpMbKWmF)_